### PR TITLE
サイト名を'サプリボックス'に修正した

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
   # メタタグを表示するメソッド
   def default_meta_tags
     {
-      site: 'サイト名',
+      site: 'サプリボックス',
       title: 'SuppleBox プロテイン口コミ・評判サイト',
       reverse: true,
       charset: 'utf-8',


### PR DESCRIPTION
タイトルに'サイト名'と表示されていたので、'サプリボックス'に修正した
修正前
```html
<title>SuppleBox プロテイン口コミ・評判サイト | サイト名</title>
```
修正後
```html
<title>SuppleBox プロテイン口コミ・評判サイト | サプリボックス</title>
```