### PR TITLE
不要なGemの削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,6 @@ group :production do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'amazon-ecs'
 gem 'aws-sdk'
 gem 'carrierwave'
 gem 'dotenv-rails'

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -41,7 +41,11 @@ class Product < ApplicationRecord
     def items(keyword)
       request.search_items(
         keywords: keyword,
+        # MEMO: 日本対応のインデックス
+        # https://webservices.amazon.com/paapi5/documentation/locale-reference/japan.html
         search_index: 'HealthPersonalCare',
+        # MEMO: 親のノードを指定すると子のノードを取得できる
+        # シナリオごとのノード https://webservices.amazon.com/paapi5/documentation/use-cases.html
         resources: [
           'ItemInfo.Title',
           'ItemInfo.ByLineInfo',


### PR DESCRIPTION
'amazon-ecs'のGemが不要になったので削除した