### PR TITLE
Herokuデプロイ時のエラー解消

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,9 +45,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    amazon-ecs (2.5.0)
-      nokogiri (~> 1.4)
-      ruby-hmac (~> 0.3)
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
@@ -1223,7 +1220,6 @@ GEM
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    ruby-hmac (0.4.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     ruby_parser (3.14.2)
@@ -1311,7 +1307,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  amazon-ecs
   aws-sdk
   bcrypt (~> 3.1.7)
   better_errors


### PR DESCRIPTION
Gemfileからgemを除いた際にbundle installをし忘れていたので実行した