### PR TITLE
Add page num to breadcrumb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ AllCops:
     - 'vendor/bundle/**/*'
     - 'public/**/*'
     - 'tmp/**/*'
+    - 'node_modules/**/*'
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,4 +36,12 @@ module ApplicationHelper
       }
     }
   end
+
+  def breadcrumb_pagination
+    if params[:page].nil? || params[:page] == 1
+      breadcrumb :products
+    else
+      breadcrumb :products_pagination, params[:page]
+    end
+  end
 end

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,4 +1,5 @@
-- breadcrumb :products
+- breadcrumb_pagination
+
 %h2 アイテム一覧情報
 .search
   .row

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -34,6 +34,11 @@ crumb :products do
   parent :root
 end
 
+crumb :products_pagination do |page|
+  link "#{page}ページ目"
+  parent :products
+end
+
 # product#show
 crumb :show_product do |product|
   link product.title.to_s, product

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,14 @@ User.create!(
   admin: true,
 )
 
+User.create!(
+  name: 'テストアカウント',
+  email: 'test@supplebox.jp',
+  password: 'testsupple',
+  password_confirmation: 'testsupple',
+  nickname: 'テスト',
+)
+
 29.times do |_n|
   name     = Faker::Name.name
   email    = Faker::Internet.email

--- a/spec/system/products_spec.rb
+++ b/spec/system/products_spec.rb
@@ -65,4 +65,27 @@ describe 'アイテム登録機能', type: :system do
       expect(page).to have_content 'プロテイン選びで失敗したくないあなたへ'
     end
   end
+
+  describe '一覧機能' do
+    before do
+      create_list(:product, 13)
+    end
+
+    it 'ユーザーはアイテム一覧を閲覧できること' do
+      visit products_path
+      expect(page).to have_content 'Home › アイテム一覧'
+      expect(page).to_not have_content 'Home › アイテム一覧 › 1ページ目'
+      expect(page).to have_selector '.pagination'
+      Product.page.each do |product|
+        expect(page).to have_link product.title, href: product_path(product)
+      end
+      within '.pagination' do
+        click_link '2'
+      end
+      expect(page).to have_content 'Home › アイテム一覧 › 2ページ目'
+      within '.breadcrumbs' do
+        expect(page).to have_link 'アイテム一覧', href: products_path
+      end
+    end
+  end
 end


### PR DESCRIPTION
アイテム一覧のパンくずリストの2ページ目以降にページ名を表示する

![ScreenShot 2020-06-28 15 16 04](https://user-images.githubusercontent.com/47182350/85947916-9255aa80-b988-11ea-8fd9-3891ea6b4277.jpg)
