### PR TITLE
Webpackコンパイルエラー修正

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,5 +1,3 @@
-import 'jquery/dist/jquery.js'
-import 'popper.js/dist/popper.js'
 import 'bootstrap/dist/js/bootstrap'
 import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-icons/font/bootstrap-icons.css'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,9 +6,9 @@
     %meta{content: "width=device-width, initial-scale=1", name: "viewport"}/
     = display_meta_tags(default_meta_tags)
     = csrf_meta_tags
-    = stylesheet_pack_tag 'application'
-    = javascript_pack_tag 'application'
+    = stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_link_tag  'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     / GoogleAnalytics
     = analytics_init if Rails.env.production?

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -2,6 +2,16 @@ const { environment } = require('@rails/webpacker')
 const { VueLoaderPlugin } = require('vue-loader')
 const vue = require('./loaders/vue')
 
+
+const webpack = require('webpack')
+environment.plugins.prepend(
+  'Provide',
+  new webpack.ProvidePlugin({
+    $: 'jquery',
+    jQuery: 'jquery',
+    Popper: 'popper.js'
+  })
+)
 environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin())
 environment.loaders.prepend('vue', vue)
 module.exports = environment


### PR DESCRIPTION
jQuery をWebpackで読み込めずコンパイルエラーになっていたので修正

<details>

```
-----> Building on the Heroku-18 stack
-----> Node.js app detected
       
-----> Creating runtime environment
       
       NPM_CONFIG_LOGLEVEL=error
       USE_YARN_CACHE=true
       NODE_ENV=production
       NODE_MODULES_CACHE=true
       NODE_VERBOSE=false
       
-----> Installing binaries
       engines.node (package.json):  unspecified
       engines.npm (package.json):   unspecified (use default)
       engines.yarn (package.json):  unspecified (use default)
       
       Resolving node version 14.x...
       Downloading and installing node 14.15.4...
       Using default npm version: 6.14.10
       Resolving yarn version 1.22.x...
       Downloading and installing yarn (1.22.10)
       Installed yarn 1.22.10
       
-----> Restoring cache
       - yarn cache
       
-----> Installing dependencies
       Installing node modules (yarn.lock)
       yarn install v1.22.10
       [1/4] Resolving packages...
       [2/4] Fetching packages...
       info fsevents@2.3.1: The platform "linux" is incompatible with this module.
       info "fsevents@2.3.1" is an optional dependency and failed compatibility check. Excluding it from installation.
       info fsevents@1.2.13: The platform "linux" is incompatible with this module.
       info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
       [3/4] Linking dependencies...
       warning " > babel-loader@8.2.2" has unmet peer dependency "webpack@>=2".
       warning " > @storybook/cli@6.1.15" has unmet peer dependency "jest@*".
       warning " > vue-loader@15.9.6" has unmet peer dependency "css-loader@*".
       warning " > vue-loader@15.9.6" has unmet peer dependency "webpack@^3.0.0 || ^4.1.0 || ^5.0.0-0".
       warning "@storybook/addon-actions > @storybook/addons@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/addons@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/api@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/api@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/client-api@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/client-api@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > react-inspector@5.1.0" has unmet peer dependency "react@^16.8.4".
       warning "@storybook/addon-links > @storybook/router@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-links > @storybook/router@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/api > @reach/router@1.3.4" has unmet peer dependency "react@15.x || 16.x || 16.4.0-alpha.0911da3".
       warning "@storybook/addon-actions > @storybook/api > @reach/router@1.3.4" has unmet peer dependency "react-dom@15.x || 16.x || 16.4.0-alpha.0911da3".
       warning "@storybook/addon-actions > @storybook/components > markdown-to-jsx@6.11.4" has unmet peer dependency "react@>= 0.14.0".
       warning "@storybook/addon-actions > @storybook/components > react-color@2.19.3" has unmet peer dependency "react@*".
       warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip@3.1.1" has unmet peer dependency "react@^16.6.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip@3.1.1" has unmet peer dependency "react-dom@^16.6.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-syntax-highlighter@13.5.3" has unmet peer dependency "react@>= 0.14.0".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize@8.3.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming > @emotion/core@10.1.1" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/theming > @emotion/styled@10.0.27" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/theming > emotion-theming@10.0.27" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/api > @reach/router > create-react-context@0.3.0" has unmet peer dependency "react@^0.14.0 || ^15.0.0 || ^16.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-color > @icons/material@0.2.4" has unmet peer dependency "react@*".
       warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip > react-popper@2.2.4" has unmet peer dependency "react@^16.8.0 || ^17".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-composed-ref@1.1.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-latest@1.2.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming > @emotion/styled > @emotion/styled-base@10.0.31" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-latest > use-isomorphic-layout-effect@1.1.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @mdx-js/react@1.6.22" has unmet peer dependency "react@^16.13.1 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/source-loader@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/source-loader@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > react-element-to-jsx-string@14.3.2" has unmet peer dependency "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1".
       warning "@storybook/addon-essentials > @storybook/addon-docs > react-element-to-jsx-string@14.3.2" has unmet peer dependency "react-dom@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "webpack-dev-server > webpack-dev-middleware@3.7.3" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > downshift@6.1.0" has unmet peer dependency "react@>=16.12.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-helmet-async@1.0.7" has unmet peer dependency "react@^16.6.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-helmet-async@1.0.7" has unmet peer dependency "react-dom@^16.6.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-hotkeys@2.0.0" has unmet peer dependency "react@>= 0.14.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-sizeme@2.6.12" has unmet peer dependency "react@^0.14.0 || ^15.0.0-0 || ^16.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-sizeme@2.6.12" has unmet peer dependency "react-dom@^0.14.0 || ^15.0.0-0 || ^16.0.0".
       warning " > @storybook/vue@6.1.15" has unmet peer dependency "css-loader@*".
       warning " > @storybook/vue@6.1.15" has unmet peer dependency "ts-loader@^6.2.2".
       warning "@storybook/vue > ts-loader@6.2.2" has unmet peer dependency "typescript@*".
       warning "@storybook/vue > vue-docgen-api > @vue/compiler-sfc@3.0.5" has incorrect peer dependency "vue@3.0.5".
       warning " > webpack-dev-server@3.11.1" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
       [4/4] Building fresh packages...
       Done in 38.25s.
       
-----> Build
       
-----> Pruning devDependencies
       yarn install v1.22.10
       [1/4] Resolving packages...
       [2/4] Fetching packages...
       info fsevents@2.3.1: The platform "linux" is incompatible with this module.
       info "fsevents@2.3.1" is an optional dependency and failed compatibility check. Excluding it from installation.
       info fsevents@1.2.13: The platform "linux" is incompatible with this module.
       info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
       [3/4] Linking dependencies...
       warning " > babel-loader@8.2.2" has unmet peer dependency "webpack@>=2".
       warning " > @storybook/cli@6.1.15" has unmet peer dependency "jest@*".
       warning " > vue-loader@15.9.6" has unmet peer dependency "css-loader@*".
       warning " > vue-loader@15.9.6" has unmet peer dependency "webpack@^3.0.0 || ^4.1.0 || ^5.0.0-0".
       warning "@storybook/addon-actions > @storybook/addons@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/addons@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/api@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/api@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/client-api@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/client-api@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > react-inspector@5.1.0" has unmet peer dependency "react@^16.8.4".
       warning "@storybook/addon-links > @storybook/router@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-links > @storybook/router@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/api > @reach/router@1.3.4" has unmet peer dependency "react@15.x || 16.x || 16.4.0-alpha.0911da3".
       warning "@storybook/addon-actions > @storybook/api > @reach/router@1.3.4" has unmet peer dependency "react-dom@15.x || 16.x || 16.4.0-alpha.0911da3".
       warning "@storybook/addon-actions > @storybook/components > markdown-to-jsx@6.11.4" has unmet peer dependency "react@>= 0.14.0".
       warning "@storybook/addon-actions > @storybook/components > react-color@2.19.3" has unmet peer dependency "react@*".
       warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip@3.1.1" has unmet peer dependency "react@^16.6.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip@3.1.1" has unmet peer dependency "react-dom@^16.6.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-syntax-highlighter@13.5.3" has unmet peer dependency "react@>= 0.14.0".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize@8.3.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming > @emotion/core@10.1.1" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/theming > @emotion/styled@10.0.27" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/theming > emotion-theming@10.0.27" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/api > @reach/router > create-react-context@0.3.0" has unmet peer dependency "react@^0.14.0 || ^15.0.0 || ^16.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-color > @icons/material@0.2.4" has unmet peer dependency "react@*".
       warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip > react-popper@2.2.4" has unmet peer dependency "react@^16.8.0 || ^17".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-composed-ref@1.1.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-latest@1.2.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming > @emotion/styled > @emotion/styled-base@10.0.31" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-latest > use-isomorphic-layout-effect@1.1.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @mdx-js/react@1.6.22" has unmet peer dependency "react@^16.13.1 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/source-loader@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/source-loader@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > react-element-to-jsx-string@14.3.2" has unmet peer dependency "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1".
       warning "@storybook/addon-essentials > @storybook/addon-docs > react-element-to-jsx-string@14.3.2" has unmet peer dependency "react-dom@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "webpack-dev-server > webpack-dev-middleware@3.7.3" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > downshift@6.1.0" has unmet peer dependency "react@>=16.12.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-helmet-async@1.0.7" has unmet peer dependency "react@^16.6.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-helmet-async@1.0.7" has unmet peer dependency "react-dom@^16.6.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-hotkeys@2.0.0" has unmet peer dependency "react@>= 0.14.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-sizeme@2.6.12" has unmet peer dependency "react@^0.14.0 || ^15.0.0-0 || ^16.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-sizeme@2.6.12" has unmet peer dependency "react-dom@^0.14.0 || ^15.0.0-0 || ^16.0.0".
       warning " > @storybook/vue@6.1.15" has unmet peer dependency "css-loader@*".
       warning " > @storybook/vue@6.1.15" has unmet peer dependency "ts-loader@^6.2.2".
       warning "@storybook/vue > ts-loader@6.2.2" has unmet peer dependency "typescript@*".
       warning "@storybook/vue > vue-docgen-api > @vue/compiler-sfc@3.0.5" has incorrect peer dependency "vue@3.0.5".
       warning " > webpack-dev-server@3.11.1" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
       [4/4] Building fresh packages...
       warning Ignored scripts due to flag.
       Done in 12.21s.
       
-----> Caching build
       - yarn cache
       
-----> Build succeeded!
 !     Unmet dependencies don't fail yarn install but may cause runtime issues
       https://github.com/npm/npm/issues/7494
-----> Ruby app detected
-----> Installing bundler 2.1.4
-----> Removing BUNDLED WITH version in the Gemfile.lock
-----> Compiling Ruby/Rails
-----> Using Ruby version: ruby-3.0.0
-----> Installing dependencies using bundler 2.1.4
       Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
       Using rake 13.0.3
       Using concurrent-ruby 1.1.7
       Using i18n 1.8.7
       Using minitest 5.14.3
       Using tzinfo 2.0.4
       Using zeitwerk 2.4.2
       Using activesupport 6.1.1
       Using builder 3.2.4
       Using erubi 1.10.0
       Using mini_portile2 2.5.0
       Using racc 1.5.2
       Using nokogiri 1.11.1 (x86_64-linux)
       Using rails-dom-testing 2.0.3
       Using crass 1.0.6
       Using loofah 2.8.0
       Using rails-html-sanitizer 1.3.0
       Using actionview 6.1.1
       Using rack 2.2.3
       Using rack-test 1.1.0
       Using actionpack 6.1.1
       Using nio4r 2.5.4
       Using websocket-extensions 0.1.5
       Using websocket-driver 0.7.3
       Using actioncable 6.1.1
       Using globalid 0.4.2
       Using activejob 6.1.1
       Using activemodel 6.1.1
       Using activerecord 6.1.1
       Using mimemagic 0.3.5
       Using marcel 0.3.3
       Using activestorage 6.1.1
       Using mini_mime 1.0.2
       Using mail 2.7.1
       Using actionmailbox 6.1.1
       Using actionmailer 6.1.1
       Using actiontext 6.1.1
       Using case_transform 0.2
       Using jsonapi-renderer 0.2.2
       Using active_model_serializers 0.10.12
       Using public_suffix 4.0.6
       Using addressable 2.7.0
       Using aws-eventstream 1.1.0
       Using aws-partitions 1.415.0
       Using aws-sigv4 1.2.2
       Using jmespath 1.4.0
       Using aws-sdk-core 3.110.0
       Using aws-sdk-accessanalyzer 1.14.0
       Using aws-sdk-acm 1.38.0
       Using aws-sdk-acmpca 1.31.0
       Using aws-sdk-alexaforbusiness 1.43.0
       Using aws-sdk-amplify 1.27.0
       Using aws-sdk-amplifybackend 1.1.0
       Using aws-sdk-apigateway 1.58.0
       Using aws-sdk-apigatewaymanagementapi 1.19.0
       Using aws-sdk-apigatewayv2 1.30.0
       Using aws-sdk-appconfig 1.12.0
       Using aws-sdk-appflow 1.4.0
       Using aws-sdk-appintegrationsservice 1.0.0
       Using aws-sdk-applicationautoscaling 1.49.0
       Using aws-sdk-applicationdiscoveryservice 1.33.0
       Using aws-sdk-applicationinsights 1.16.0
       Using aws-sdk-appmesh 1.33.0
       Using aws-sdk-appregistry 1.3.0
       Using aws-sdk-appstream 1.48.0
       Using aws-sdk-appsync 1.37.0
       Using aws-sdk-athena 1.33.0
       Using aws-sdk-auditmanager 1.0.0
       Using aws-sdk-augmentedairuntime 1.10.0
       Using aws-sdk-autoscaling 1.53.0
       Using aws-sdk-autoscalingplans 1.29.0
       Using aws-sdk-backup 1.25.0
       Using aws-sdk-batch 1.43.0
       Using aws-sdk-braket 1.5.0
       Using aws-sdk-budgets 1.36.0
       Using aws-sdk-chime 1.39.0
       Using aws-sdk-cloud9 1.29.0
       Using aws-sdk-clouddirectory 1.29.0
       Using aws-sdk-cloudformation 1.46.0
       Using aws-sdk-cloudfront 1.47.0
       Using aws-sdk-cloudhsm 1.27.0
       Using aws-sdk-cloudhsmv2 1.31.0
       Using aws-sdk-cloudsearch 1.27.0
       Using aws-sdk-cloudsearchdomain 1.22.0
       Using aws-sdk-cloudtrail 1.31.0
       Using aws-sdk-cloudwatch 1.47.0
       Using aws-sdk-cloudwatchevents 1.40.0
       Using aws-sdk-cloudwatchlogs 1.38.0
       Using aws-sdk-codeartifact 1.6.0
       Using aws-sdk-codebuild 1.65.0
       Using aws-sdk-codecommit 1.40.0
       Using aws-sdk-codedeploy 1.37.0
       Using aws-sdk-codeguruprofiler 1.12.0
       Using aws-sdk-codegurureviewer 1.14.0
       Using aws-sdk-codepipeline 1.39.0
       Using aws-sdk-codestar 1.27.0
       Using aws-sdk-codestarconnections 1.12.0
       Using aws-sdk-codestarnotifications 1.8.0
       Using aws-sdk-cognitoidentity 1.28.0
       Using aws-sdk-cognitoidentityprovider 1.48.0
       Using aws-sdk-cognitosync 1.24.0
       Using aws-sdk-comprehend 1.42.0
       Using aws-sdk-comprehendmedical 1.23.0
       Using aws-sdk-computeoptimizer 1.11.0
       Using aws-sdk-configservice 1.55.0
       Using aws-sdk-connect 1.38.0
       Using aws-sdk-connectcontactlens 1.0.0
       Using aws-sdk-connectparticipant 1.9.0
       Using aws-sdk-costandusagereportservice 1.28.0
       Using aws-sdk-costexplorer 1.56.0
       Using aws-sdk-customerprofiles 1.1.0
       Using aws-sdk-databasemigrationservice 1.50.0
       Using aws-sdk-dataexchange 1.10.0
       Using aws-sdk-datapipeline 1.24.0
       Using aws-sdk-datasync 1.28.0
       Using aws-sdk-dax 1.27.0
       Using aws-sdk-detective 1.11.0
       Using aws-sdk-devicefarm 1.39.0
       Using aws-sdk-devopsguru 1.2.0
       Using aws-sdk-directconnect 1.37.0
       Using aws-sdk-directoryservice 1.37.0
       Using aws-sdk-dlm 1.37.0
       Using aws-sdk-docdb 1.27.0
       Using aws-sdk-dynamodb 1.58.0
       Using aws-sdk-dynamodbstreams 1.26.0
       Using aws-sdk-ebs 1.11.0
       Using aws-sdk-ec2 1.220.0
       Using aws-sdk-ec2instanceconnect 1.11.0
       Using aws-sdk-ecr 1.40.0
       Using aws-sdk-ecrpublic 1.0.0
       Using aws-sdk-ecs 1.72.0
       Using aws-sdk-efs 1.36.0
       Using aws-sdk-eks 1.46.0
       Using aws-sdk-elasticache 1.49.0
       Using aws-sdk-elasticbeanstalk 1.40.0
       Using aws-sdk-elasticinference 1.10.0
       Using aws-sdk-elasticloadbalancing 1.29.0
       Using aws-sdk-elasticloadbalancingv2 1.56.0
       Using aws-sdk-elasticsearchservice 1.46.0
       Using aws-sdk-elastictranscoder 1.27.0
       Using aws-sdk-emr 1.40.0
       Using aws-sdk-emrcontainers 1.0.0
       Using aws-sdk-eventbridge 1.18.0
       Using aws-sdk-firehose 1.35.0
       Using aws-sdk-fms 1.33.0
       Using aws-sdk-forecastqueryservice 1.10.0
       Using aws-sdk-forecastservice 1.14.0
       Using aws-sdk-frauddetector 1.14.0
       Using aws-sdk-fsx 1.33.0
       Using aws-sdk-gamelift 1.39.0
       Using aws-sdk-glacier 1.35.0
       Using aws-sdk-globalaccelerator 1.27.0
       Using aws-sdk-glue 1.82.0
       Using aws-sdk-gluedatabrew 1.0.0
       Using aws-sdk-greengrass 1.37.0
       Using aws-sdk-greengrassv2 1.0.0
       Using aws-sdk-groundstation 1.15.0
       Using aws-sdk-guardduty 1.43.0
       Using aws-sdk-health 1.31.0
       Using aws-sdk-healthlake 1.1.0
       Using aws-sdk-honeycode 1.4.0
       Using aws-sdk-iam 1.46.0
       Using aws-sdk-identitystore 1.3.0
       Using aws-sdk-imagebuilder 1.17.0
       Using aws-sigv2 1.0.1
       Using aws-sdk-importexport 1.24.0
       Using aws-sdk-inspector 1.32.0
       Using aws-sdk-iot 1.64.0
       Using aws-sdk-iot1clickdevicesservice 1.26.0
       Using aws-sdk-iot1clickprojects 1.26.0
       Using aws-sdk-iotanalytics 1.36.0
       Using aws-sdk-iotdataplane 1.26.0
       Using aws-sdk-iotdeviceadvisor 1.0.0
       Using aws-sdk-iotevents 1.20.0
       Using aws-sdk-ioteventsdata 1.13.0
       Using aws-sdk-iotfleethub 1.0.0
       Using aws-sdk-iotjobsdataplane 1.25.0
       Using aws-sdk-iotsecuretunneling 1.9.0
       Using aws-sdk-iotsitewise 1.16.0
       Using aws-sdk-iotthingsgraph 1.12.0
       Using aws-sdk-iotwireless 1.1.0
       Using aws-sdk-ivs 1.5.0
       Using aws-sdk-kafka 1.32.0
       Using aws-sdk-kendra 1.20.0
       Using aws-sdk-kinesis 1.30.0
       Using aws-sdk-kinesisanalytics 1.29.0
       Using aws-sdk-kinesisanalyticsv2 1.24.0
       Using aws-sdk-kinesisvideo 1.30.0
       Using aws-sdk-kinesisvideoarchivedmedia 1.29.0
       Using aws-sdk-kinesisvideomedia 1.26.0
       Using aws-sdk-kinesisvideosignalingchannels 1.8.0
       Using aws-sdk-kms 1.40.0
       Using aws-sdk-lakeformation 1.11.0
       Using aws-sdk-lambda 1.57.0
       Using aws-sdk-lambdapreview 1.24.0
       Using aws-sdk-lex 1.33.0
       Using aws-sdk-lexmodelbuildingservice 1.42.0
       Using aws-sdk-licensemanager 1.23.0
       Using aws-sdk-lightsail 1.40.0
       Using aws-sdk-locationservice 1.0.0
       Using aws-sdk-lookoutforvision 1.0.0
       Using aws-sdk-machinelearning 1.25.0
       Using aws-sdk-macie 1.25.0
       Using aws-sdk-macie2 1.19.0
       Using aws-sdk-managedblockchain 1.18.0
       Using aws-sdk-marketplacecatalog 1.9.0
       Using aws-sdk-marketplacecommerceanalytics 1.30.0
       Using aws-sdk-marketplaceentitlementservice 1.24.0
       Using aws-sdk-marketplacemetering 1.32.0
       Using aws-sdk-mediaconnect 1.28.0
       Using aws-sdk-mediaconvert 1.61.0
       Using aws-sdk-medialive 1.61.0
       Using aws-sdk-mediapackage 1.36.0
       Using aws-sdk-mediapackagevod 1.19.0
       Using aws-sdk-mediastore 1.30.0
       Using aws-sdk-mediastoredata 1.27.0
       Using aws-sdk-mediatailor 1.33.0
       Using aws-sdk-migrationhub 1.29.0
       Using aws-sdk-migrationhubconfig 1.9.0
       Using aws-sdk-mobile 1.24.0
       Using aws-sdk-mq 1.34.0
       Using aws-sdk-mturk 1.27.0
       Using aws-sdk-mwaa 1.0.0
       Using aws-sdk-neptune 1.32.0
       Using aws-sdk-networkfirewall 1.0.0
       Using aws-sdk-networkmanager 1.9.0
       Using aws-sdk-opsworks 1.30.0
       Using aws-sdk-opsworkscm 1.40.0
       Using aws-sdk-organizations 1.55.0
       Using aws-sdk-outposts 1.13.0
       Using aws-sdk-personalize 1.19.0
       Using aws-sdk-personalizeevents 1.14.0
       Using aws-sdk-personalizeruntime 1.20.0
       Using aws-sdk-pi 1.25.0
       Using aws-sdk-pinpoint 1.47.0
       Using aws-sdk-pinpointemail 1.24.0
       Using aws-sdk-pinpointsmsvoice 1.21.0
       Using aws-sdk-polly 1.38.0
       Using aws-sdk-pricing 1.24.0
       Using aws-sdk-prometheusservice 1.1.0
       Using aws-sdk-qldb 1.11.0
       Using aws-sdk-qldbsession 1.10.0
       Using aws-sdk-quicksight 1.39.0
       Using aws-sdk-ram 1.22.0
       Using aws-sdk-rds 1.109.0
       Using aws-sdk-rdsdataservice 1.23.0
       Using aws-sdk-redshift 1.52.0
       Using aws-sdk-redshiftdataapiservice 1.2.0
       Using aws-sdk-rekognition 1.47.0
       Using aws-sdk-resourcegroups 1.33.0
       Using aws-sdk-resourcegroupstaggingapi 1.34.0
       Using aws-sdk-robomaker 1.31.0
       Using aws-sdk-route53 1.45.0
       Using aws-sdk-route53domains 1.28.0
       Using aws-sdk-route53resolver 1.22.0
       Using aws-sdk-s3 1.87.0
       Using aws-sdk-s3control 1.25.0
       Using aws-sdk-s3outposts 1.0.0
       Using aws-sdk-sagemaker 1.74.0
       Using aws-sdk-sagemakeredgemanager 1.0.0
       Using aws-sdk-sagemakerfeaturestoreruntime 1.0.0
       Using aws-sdk-sagemakerruntime 1.28.0
       Using aws-sdk-savingsplans 1.12.0
       Using aws-sdk-schemas 1.10.0
       Using aws-sdk-secretsmanager 1.43.0
       Using aws-sdk-securityhub 1.37.0
       Using aws-sdk-serverlessapplicationrepository 1.32.0
       Using aws-sdk-servicecatalog 1.57.0
       Using aws-sdk-servicediscovery 1.31.0
       Using aws-sdk-servicequotas 1.12.0
       Using aws-sdk-ses 1.36.0
       Using aws-sdk-sesv2 1.14.0
       Using aws-sdk-shield 1.33.0
       Using aws-sdk-signer 1.27.0
       Using aws-sdk-simpledb 1.24.0
       Using aws-sdk-sms 1.27.0
       Using aws-sdk-snowball 1.35.0
       Using aws-sdk-sns 1.36.0
       Using aws-sdk-sqs 1.35.0
       Using aws-sdk-ssm 1.101.0
       Using aws-sdk-ssoadmin 1.4.0
       Using aws-sdk-ssooidc 1.8.0
       Using aws-sdk-states 1.37.0
       Using aws-sdk-storagegateway 1.52.0
       Using aws-sdk-support 1.28.0
       Using aws-sdk-swf 1.25.0
       Using aws-sdk-synthetics 1.10.0
       Using aws-sdk-textract 1.22.0
       Using aws-sdk-timestreamquery 1.2.0
       Using aws-sdk-timestreamwrite 1.2.0
       Using aws-sdk-transcribeservice 1.50.0
       Using aws-sdk-transcribestreamingservice 1.24.0
       Using aws-sdk-transfer 1.29.0
       Using aws-sdk-translate 1.29.0
       Using aws-sdk-waf 1.36.0
       Using aws-sdk-wafregional 1.37.0
       Using aws-sdk-wafv2 1.14.0
       Using aws-sdk-wellarchitected 1.0.0
       Using aws-sdk-workdocs 1.28.0
       Using aws-sdk-worklink 1.21.0
       Using aws-sdk-workmail 1.33.0
       Using aws-sdk-workmailmessageflow 1.9.0
       Using aws-sdk-workspaces 1.49.0
       Using aws-sdk-xray 1.35.0
       Using aws-sdk-resources 3.93.0
       Using aws-sdk 3.0.1
       Using bcrypt 3.1.16
       Using msgpack 1.3.3
       Using bootsnap 1.5.1
       Using bundler 2.2.3
       Using mini_magick 4.11.0
       Using ffi 1.14.2
       Using ruby-vips 2.0.17
       Using image_processing 1.12.1
       Using carrierwave 2.1.0
       Using unf_ext 0.0.7.7
       Using unf 0.1.4
       Using domain_name 0.5.20190701
       Using dotenv 2.7.6
       Using method_source 1.0.0
       Using thor 1.0.1
       Using railties 6.1.1
       Using dotenv-rails 2.7.6
       Using erubis 2.7.0
       Using excon 0.78.1
       Using execjs 2.7.0
       Using faker 2.15.1
       Using ffi-compiler 1.0.1
       Using formatador 0.2.5
       Using mime-types-data 3.2020.1104
       Using mime-types 3.3.1
       Using fog-core 2.2.3
       Using multi_json 1.15.0
       Using fog-json 1.2.0
       Using fog-xml 0.1.3
       Using ipaddress 0.8.3
       Using fog-aws 3.7.0
       Using google-analytics-rails 1.1.1
       Using gretel 4.2.0
       Using temple 0.8.2
       Using tilt 2.0.10
       Using haml 5.2.1
       Using sexp_processor 4.15.1
       Using ruby_parser 3.15.0
       Using html2haml 2.2.0
       Using haml-rails 2.0.1
       Using http-cookie 1.0.3
       Using http-form_data 2.3.0
       Using http-parser 1.2.2
       Using http 4.4.1
       Using jbuilder 2.10.1
       Using jquery-rails 4.4.0
       Using jquery-ui-rails 6.0.1
       Using kaminari-core 1.2.1
       Using kaminari-actionview 1.2.1
       Using kaminari-activerecord 1.2.1
       Using kaminari 1.2.1
       Using meta-tags 2.14.0
       Using pg 1.2.3
       Using puma 5.1.1
       Using rack-proxy 0.6.5
       Using sprockets 4.0.2
       Using sprockets-rails 3.2.2
       Using rails 6.1.1
       Using ransack 2.4.1
       Using sassc 2.4.0
       Using sassc-rails 2.1.2
       Using sass-rails 6.0.0
       Using semantic_range 2.3.1
       Using sitemap_generator 6.1.2
       Using turbolinks-source 5.2.0
       Using turbolinks 5.2.1
       Using uglifier 4.2.0
       Using vacuum 3.4.1
       Using webpacker 5.2.1
       Bundle complete! 50 Gemfile dependencies, 374 gems now installed.
       Gems in the groups development and test were not installed.
       Bundled gems are installed into `./vendor/bundle`
       Removing bundler (2.1.4)
       Bundle completed (1.59s)
       Cleaning up the bundler cache.
-----> Detecting rake tasks
-----> Preparing app for Rails asset pipeline
       Running: rake assets:precompile
       yarn install v1.22.10
       [1/4] Resolving packages...
       [2/4] Fetching packages...
       info fsevents@2.3.1: The platform "linux" is incompatible with this module.
       info "fsevents@2.3.1" is an optional dependency and failed compatibility check. Excluding it from installation.
       info fsevents@1.2.13: The platform "linux" is incompatible with this module.
       info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
       [3/4] Linking dependencies...
       warning " > babel-loader@8.2.2" has unmet peer dependency "webpack@>=2".
       warning " > @storybook/cli@6.1.15" has unmet peer dependency "jest@*".
       warning " > vue-loader@15.9.6" has unmet peer dependency "css-loader@*".
       warning " > vue-loader@15.9.6" has unmet peer dependency "webpack@^3.0.0 || ^4.1.0 || ^5.0.0-0".
       warning "@storybook/addon-actions > @storybook/addons@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/addons@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/api@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/api@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/client-api@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/client-api@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > react-inspector@5.1.0" has unmet peer dependency "react@^16.8.4".
       warning "@storybook/addon-links > @storybook/router@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-links > @storybook/router@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/api > @reach/router@1.3.4" has unmet peer dependency "react@15.x || 16.x || 16.4.0-alpha.0911da3".
       warning "@storybook/addon-actions > @storybook/api > @reach/router@1.3.4" has unmet peer dependency "react-dom@15.x || 16.x || 16.4.0-alpha.0911da3".
       warning "@storybook/addon-actions > @storybook/components > markdown-to-jsx@6.11.4" has unmet peer dependency "react@>= 0.14.0".
       warning "@storybook/addon-actions > @storybook/components > react-color@2.19.3" has unmet peer dependency "react@*".
       warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip@3.1.1" has unmet peer dependency "react@^16.6.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip@3.1.1" has unmet peer dependency "react-dom@^16.6.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-syntax-highlighter@13.5.3" has unmet peer dependency "react@>= 0.14.0".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize@8.3.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming > @emotion/core@10.1.1" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/theming > @emotion/styled@10.0.27" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/theming > emotion-theming@10.0.27" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/api > @reach/router > create-react-context@0.3.0" has unmet peer dependency "react@^0.14.0 || ^15.0.0 || ^16.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-color > @icons/material@0.2.4" has unmet peer dependency "react@*".
       warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip > react-popper@2.2.4" has unmet peer dependency "react@^16.8.0 || ^17".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-composed-ref@1.1.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-latest@1.2.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-actions > @storybook/theming > @emotion/styled > @emotion/styled-base@10.0.31" has unmet peer dependency "react@>=16.3.0".
       warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-latest > use-isomorphic-layout-effect@1.1.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @mdx-js/react@1.6.22" has unmet peer dependency "react@^16.13.1 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/source-loader@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/source-loader@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > react-element-to-jsx-string@14.3.2" has unmet peer dependency "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1".
       warning "@storybook/addon-essentials > @storybook/addon-docs > react-element-to-jsx-string@14.3.2" has unmet peer dependency "react-dom@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui@6.1.15" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui@6.1.15" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
       warning "webpack-dev-server > webpack-dev-middleware@3.7.3" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > downshift@6.1.0" has unmet peer dependency "react@>=16.12.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-helmet-async@1.0.7" has unmet peer dependency "react@^16.6.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-helmet-async@1.0.7" has unmet peer dependency "react-dom@^16.6.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-hotkeys@2.0.0" has unmet peer dependency "react@>= 0.14.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-sizeme@2.6.12" has unmet peer dependency "react@^0.14.0 || ^15.0.0-0 || ^16.0.0".
       warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/ui > react-sizeme@2.6.12" has unmet peer dependency "react-dom@^0.14.0 || ^15.0.0-0 || ^16.0.0".
       warning " > @storybook/vue@6.1.15" has unmet peer dependency "css-loader@*".
       warning " > @storybook/vue@6.1.15" has unmet peer dependency "ts-loader@^6.2.2".
       warning "@storybook/vue > ts-loader@6.2.2" has unmet peer dependency "typescript@*".
       warning "@storybook/vue > vue-docgen-api > @vue/compiler-sfc@3.0.5" has incorrect peer dependency "vue@3.0.5".
       warning " > webpack-dev-server@3.11.1" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
       [4/4] Building fresh packages...
       Done in 68.14s.
       Compiling...
       Compilation failed:
       ModuleNotFoundError: Module not found: Error: Can't resolve 'jquery/dist/jquery.js' in '/tmp/build_9da8714d_/app/javascript/packs'
           at /tmp/build_9da8714d_/node_modules/webpack/lib/Compilation.js:925:10
           at /tmp/build_9da8714d_/node_modules/webpack/lib/NormalModuleFactory.js:401:22
           at /tmp/build_9da8714d_/node_modules/webpack/lib/NormalModuleFactory.js:130:21
           at /tmp/build_9da8714d_/node_modules/webpack/lib/NormalModuleFactory.js:224:22
           at /tmp/build_9da8714d_/node_modules/neo-async/async.js:2830:7
           at /tmp/build_9da8714d_/node_modules/neo-async/async.js:6877:13
           at /tmp/build_9da8714d_/node_modules/webpack/lib/NormalModuleFactory.js:214:25
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:213:14
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:285:5
           at eval (eval at create (/tmp/build_9da8714d_/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js:44:7
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:285:5
           at eval (eval at create (/tmp/build_9da8714d_/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:285:5
           at eval (eval at create (/tmp/build_9da8714d_/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/DescriptionFilePlugin.js:67:43
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:285:5
           at eval (eval at create (/tmp/build_9da8714d_/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:43:1)
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/ModuleKindPlugin.js:30:40
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:285:5
           at eval (eval at create (/tmp/build_9da8714d_/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:285:5
           at eval (eval at create (/tmp/build_9da8714d_/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:16:1)
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/forEachBail.js:30:14
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:285:5
           at eval (eval at create (/tmp/build_9da8714d_/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js:44:7
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:285:5
           at eval (eval at create (/tmp/build_9da8714d_/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:285:5
           at eval (eval at create (/tmp/build_9da8714d_/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/DescriptionFilePlugin.js:67:43
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:285:5
           at eval (eval at create (/tmp/build_9da8714d_/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:16:1)
           at /tmp/build_9da8714d_/node_modules/enhanced-resolve/lib/Resolver.js:285:5
           at eval (eval at create (/tmp/build_9da8714d_/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)
       resolve 'jquery/dist/jquery.js' in '/tmp/build_9da8714d_/app/javascript/packs'
         Parsed request is a module
         using description file: /tmp/build_9da8714d_/package.json (relative path: ./app/javascript/packs)
           Field 'browser' doesn't contain a valid alias configuration
           resolve as module
             looking for modules in /tmp/build_9da8714d_/app/javascript
               using description file: /tmp/build_9da8714d_/package.json (relative path: ./app/javascript)
                 Field 'browser' doesn't contain a valid alias configuration
                 using description file: /tmp/build_9da8714d_/package.json (relative path: ./app/javascript/jquery/dist/jquery.js)
                   no extension
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js doesn't exist
                   .vue
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.vue doesn't exist
                   .mjs
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.mjs doesn't exist
                   .js
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.js doesn't exist
                   .sass
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.sass doesn't exist
                   .scss
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.scss doesn't exist
                   .css
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.css doesn't exist
                   .module.sass
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.module.sass doesn't exist
                   .module.scss
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.module.scss doesn't exist
                   .module.css
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.module.css doesn't exist
                   .png
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.png doesn't exist
                   .svg
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.svg doesn't exist
                   .gif
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.gif doesn't exist
                   .jpeg
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.jpeg doesn't exist
                   .jpg
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js.jpg doesn't exist
                   as directory
                     /tmp/build_9da8714d_/app/javascript/jquery/dist/jquery.js doesn't exist
             /tmp/build_9da8714d_/app/javascript/packs/node_modules doesn't exist or is not a directory
             /tmp/build_9da8714d_/app/javascript/node_modules doesn't exist or is not a directory
             /tmp/build_9da8714d_/app/node_modules doesn't exist or is not a directory
             /tmp/node_modules doesn't exist or is not a directory
             /node_modules doesn't exist or is not a directory
             looking for modules in /tmp/build_9da8714d_/node_modules
               using description file: /tmp/build_9da8714d_/package.json (relative path: ./node_modules)
                 Field 'browser' doesn't contain a valid alias configuration
                 using description file: /tmp/build_9da8714d_/package.json (relative path: ./node_modules/jquery/dist/jquery.js)
                   no extension
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js doesn't exist
                   .vue
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.vue doesn't exist
                   .mjs
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.mjs doesn't exist
                   .js
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.js doesn't exist
                   .sass
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.sass doesn't exist
                   .scss
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.scss doesn't exist
                   .css
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.css doesn't exist
                   .module.sass
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.module.sass doesn't exist
                   .module.scss
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.module.scss doesn't exist
                   .module.css
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.module.css doesn't exist
                   .png
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.png doesn't exist
                   .svg
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.svg doesn't exist
                   .gif
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.gif doesn't exist
                   .jpeg
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.jpeg doesn't exist
                   .jpg
                     Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js.jpg doesn't exist
                   as directory
                     /tmp/build_9da8714d_/node_modules/jquery/dist/jquery.js doesn't exist
       
 !
 !     Precompiling assets failed.
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed
```

</details>