### PR TITLE
商品一覧画面のVue化

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,6 +12,13 @@ module.exports = {
   ],
   webpackFinal: async (config) => {
     config.resolve.alias['@axios'] = path.resolve(__dirname, '../app/javascript/packs/initializers/axios.js');
+
+    config.module.rules.push({
+      test: /\.scss$/,
+      use: ['style-loader', 'css-loader', 'sass-loader'],
+      include: path.resolve(__dirname, '../'),
+    })
+
     return config;
   },
 }

--- a/app/javascript/components/ProductList/index.stories.js
+++ b/app/javascript/components/ProductList/index.stories.js
@@ -1,0 +1,19 @@
+import ProductList from './index'
+
+export default {
+  title: 'Components/ProductList',
+  component: ProductList,
+  argTypes: {
+  },
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { ProductList },
+  template: `<ProductList
+    />`,
+});
+
+export const Default = Template.bind({})
+Default.args = {
+}

--- a/app/javascript/components/ProductList/index.vue
+++ b/app/javascript/components/ProductList/index.vue
@@ -42,8 +42,10 @@ export default {
 }
 </script>
 
-<style scoped>
-.product-list__header {
-  text-align: center;
+<style lang="scss" scoped>
+.product-list{
+  &__header {
+    text-align: center;
+  }
 }
 </style>

--- a/app/javascript/components/ProductList/index.vue
+++ b/app/javascript/components/ProductList/index.vue
@@ -1,0 +1,18 @@
+<template>
+</template>
+
+<script>
+
+export default {
+  name: 'ProductList',
+  props: {
+    product: {
+      type: Object,
+      required: true
+    }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/components/ProductList/index.vue
+++ b/app/javascript/components/ProductList/index.vue
@@ -1,4 +1,32 @@
 <template>
+  <div class="product-list">
+    <div class="product-list__header">
+      <h2>
+        アイテム一覧
+      </h2>
+    </div>
+    <div class="row justify-content-center">
+      <div class="product-list__form form-inline">
+        <div class="form-group">
+          <input
+            id="q_title_or_brand_amazon_name_cont"
+            class="form-control input-lg"
+            placeholder="ブランドやアイテム名を入力"
+            size="40"
+            type="text"
+            name="q[title_or_brand_amazon_name_cont]"
+          >
+        </div>
+        <input
+          type="submit"
+          name="commit"
+          value="アイテムを検索"
+          class="btn btn-success"
+          data-disable-with="アイテムを検索"
+        >
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -15,4 +43,7 @@ export default {
 </script>
 
 <style scoped>
+.product-list__header {
+  text-align: center;
+}
 </style>


### PR DESCRIPTION
## TODO
- [ ] 一覧画面のコンポーネント作成
  - [x] 見出し追加
  - [x] 検索フォームのテンプレート
  - [x] 一覧のテンプレート
  - [x] APIのロジック
- [ ] 無限スクロール機能を追加する
- [ ] 検索フォームから検索できるようにする
- [ ] 検索フォームを一覧画面から分離して新しいコンポーネント作成
- [ ] 一覧画面からAPI通信ロジックをVuexに切り出す

## 課題
- Vueファイル上でSCSSが使えない(ので、ローダーを追加する必要がありそう)
  Ref: https://storybook.js.org/docs/react/configure/webpack#extending-storybooks-webpack-config