### PR TITLE
Eisable extract_css for production

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,8 +12,6 @@
     = stylesheet_link_tag  'application', media: 'all'
     / app/assets/javascripts
     = javascript_include_tag 'application'
-
-    = stylesheet_pack_tag  'application', media: 'all'
     / GoogleAnalytics
     = analytics_init if Rails.env.production?
   %body

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,6 +12,8 @@
     = stylesheet_link_tag  'application', media: 'all'
     / app/assets/javascripts
     = javascript_include_tag 'application'
+
+    = stylesheet_pack_tag  'application', media: 'all'
     / GoogleAnalytics
     = analytics_init if Rails.env.production?
   %body

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -89,7 +89,8 @@ production:
   compile: false
 
   # Extract and emit a css file
-  extract_css: true
+  # trueにするとCSSを読み込めないため
+  extract_css: false
 
   # Cache manifest.json for performance
   cache_manifest: true


### PR DESCRIPTION
ref https://webpack.js.org/plugins/mini-css-extract-plugin/

extract_cssが有効だと、バンドルしたjsファイルからcssを分離する。
これはパフォーマンス等の面から有用であるが、分離したcssをうまくインポートできないため、disableにする。